### PR TITLE
Refactor bib.tex and ~bib.tex

### DIFF
--- a/bib.tex
+++ b/bib.tex
@@ -1,16 +1,11 @@
 
 @Proceedings{COPA2017,
-  name = {IJCAI 2017 Workshop on Artificial Intelligence in Affective Computing},
-  booktitle = {Proceedings of IJCAI 2017 Workshop on Artificial Intelligence in Affective Computing},
+  title =     {Proceedings of Machine Learning Research},
+  booktitle = {Proceedings of Machine Learning Research},
   editor =    {Heath Yates and William Hsu and Brent Chamberlain and Joshua Weese},
   publisher = {PMLR},
   series =    {Proceedings of Machine Learning Research},
-  volume =    66,
-  start = {2017-08-20},
-  end = {2017-08-20},
-  url ={http://kdd.cs.ksu.edu/Workshops/IJCAI-2017-AffComp/},
-  location = {Melbourne, Australia},
-  published = {2017-09-15}
+  volume =    66
 }
 
 
@@ -34,7 +29,7 @@
 
 @InProceedings{Jaques17,
   title = {Predicting Tomorrow's Mood, Health, and Stress Level using Personalized Multitask Learning and Domain Adaptation},
-  author = {Jaques, Natasha and Rudovic, Ognen (Oggi) and Taylor, Sara and Sano, Akane and Picard, Rosalind},
+  author = {Jaques, Natasha and Rudovic, Ognjen (Oggi) and Taylor, Sara and Sano, Akane and Picard, Rosalind},
   booktitle = {Proceedings of IJCAI 2017 Workshop on Artificial Intelligence in Affective Computing},
   pages = 	 {17--33},
   year = 	 {2017},
@@ -46,7 +41,7 @@
   publisher = {PMLR},
   pdf = 	 {http://proceedings.mlr.press/v66/Jaques17/Jaques17.pdf},
   url = 	 {http://proceedings.mlr.press/v66/Jaques17.html},
-  abstract = {We treat predicting tomorrow's mood for a single person as one task using MTL deep neural network and Gaussian Process with DA}
+  abstract = {We treat predicting tomorrow's mood for a single person as one task using MTL deep neural network and Gaussian process with DA}
 }
 
 @InProceedings{Atcheson17,
@@ -63,7 +58,7 @@
   publisher = {PMLR},
   pdf = 	 {http://proceedings.mlr.press/v66/Atcheson17/Atcheson17.pdf},
   url = 	 {http://proceedings.mlr.press/v66/Atcheson17.html},
-  abstract = {Demonstrate application of Gaussian process regression (GPR) with convariance structure is able to make predictions of emotional arousal from audio with over twice the accuracy of straighforward pointwise application of GPR}
+  abstract = {Demonstrate application of Gaussian process regression (GPR) with covariance structure is able to make predictions of emotional arousal from audio with over twice the accuracy of straightforward pointwise application of GPR}
 }
 
 @InProceedings{Li17,
@@ -80,7 +75,7 @@
   publisher = {PMLR},
   pdf = 	 {http://proceedings.mlr.press/v66/Li17/Li17.pdf},
   url = 	 {http://proceedings.mlr.press/v66/Li17.html},
-  abstract = {Our work shows that automatically obtained word embedding outperforms manually constructed affective lexicons using LSTM learning method using word embedding}
+  abstract = {Our work shows that automatically obtained word embedding outperforms manually constructed affective lexicons using LTSM learning method using word embedding}
 }
 
 @InProceedings{Yates17,

--- a/bib.tex
+++ b/bib.tex
@@ -6,7 +6,7 @@
   series =    {Proceedings of Machine Learning Research},
   volume =    66, 
   start = {2017-08-20},
-  end = {2018-08-20}, 
+  end = {2017-08-20}, 
   url = {http://kdd.cs.ksu.edu/Workshops/IJCAI-2017-AffComp/},
   location = {Melbourne, Australia}, 
   published = {2017-09-15}

--- a/bib.tex
+++ b/bib.tex
@@ -1,11 +1,15 @@
-
-@Proceedings{COPA2017,
-  title =     {Proceedings of Machine Learning Research},
-  booktitle = {Proceedings of Machine Learning Research},
+@Proceedings{AFFYCOMP2017,
+  title =     {IJCAI 2017 Workshop on Artificial Intelligence in Affective Computing},
+  booktitle = {Proceedings of ICJAI2017 Workshop on Artificial Intelligence in Affective Computing},
   editor =    {Heath Yates and William Hsu and Brent Chamberlain and Joshua Weese},
   publisher = {PMLR},
   series =    {Proceedings of Machine Learning Research},
-  volume =    66
+  volume =    66, 
+  start = {2017-08-20},
+  end = {2018-08-20}, 
+  url = {http://kdd.cs.ksu.edu/Workshops/IJCAI-2017-AffComp/},
+  location = {Melbourne, Australia}, 
+  published = {2017-09-15}
 }
 
 
@@ -75,7 +79,7 @@
   publisher = {PMLR},
   pdf = 	 {http://proceedings.mlr.press/v66/Li17/Li17.pdf},
   url = 	 {http://proceedings.mlr.press/v66/Li17.html},
-  abstract = {Our work shows that automatically obtained word embedding outperforms manually constructed affective lexicons using LTSM learning method using word embedding}
+  abstract = {Our work shows that automatically obtained word embedding outperforms manually constructed affective lexicons using LSTM learning method using word embedding}
 }
 
 @InProceedings{Yates17,

--- a/bib.tex~
+++ b/bib.tex~
@@ -6,7 +6,7 @@
   series =    {Proceedings of Machine Learning Research},
   volume =    66, 
   start = {2017-08-20},
-  end = {2018-08-20}, 
+  end = {2017-08-20}, 
   url = {http://kdd.cs.ksu.edu/Workshops/IJCAI-2017-AffComp/},
   location = {Melbourne, Australia}, 
   published = {2017-09-15}

--- a/bib.tex~
+++ b/bib.tex~
@@ -1,11 +1,15 @@
-
-@Proceedings{COPA2017,
-  title =     {Proceedings of Machine Learning Research},
-  booktitle = {Proceedings of Machine Learning Research},
+@Proceedings{AFFYCOMP2017,
+  title =     {IJCAI 2017 Workshop on Artificial Intelligence in Affective Computing},
+  booktitle = {Proceedings of ICJAI2017 Workshop on Artificial Intelligence in Affective Computing},
   editor =    {Heath Yates and William Hsu and Brent Chamberlain and Joshua Weese},
   publisher = {PMLR},
   series =    {Proceedings of Machine Learning Research},
-  volume =    66
+  volume =    66, 
+  start = {2017-08-20},
+  end = {2018-08-20}, 
+  url = {http://kdd.cs.ksu.edu/Workshops/IJCAI-2017-AffComp/},
+  location = {Melbourne, Australia}, 
+  published = {2017-09-15}
 }
 
 
@@ -29,7 +33,7 @@
 
 @InProceedings{Jaques17,
   title = {Predicting Tomorrow's Mood, Health, and Stress Level using Personalized Multitask Learning and Domain Adaptation},
-  author = {Jaques, Natasha and Rudovic, Ognen (Oggi) and Taylor, Sara and Sano, Akane and Picard, Rosalind},
+  author = {Jaques, Natasha and Rudovic, Ognjen (Oggi) and Taylor, Sara and Sano, Akane and Picard, Rosalind},
   booktitle = {Proceedings of IJCAI 2017 Workshop on Artificial Intelligence in Affective Computing},
   pages = 	 {17--33},
   year = 	 {2017},
@@ -41,7 +45,7 @@
   publisher = {PMLR},
   pdf = 	 {http://proceedings.mlr.press/v66/Jaques17/Jaques17.pdf},
   url = 	 {http://proceedings.mlr.press/v66/Jaques17.html},
-  abstract = {We treat predicting tomorrow's mood for a single person as one task using MTL deep neural network and Gaussian Process with DA}
+  abstract = {We treat predicting tomorrow's mood for a single person as one task using MTL deep neural network and Gaussian process with DA}
 }
 
 @InProceedings{Atcheson17,
@@ -58,7 +62,7 @@
   publisher = {PMLR},
   pdf = 	 {http://proceedings.mlr.press/v66/Atcheson17/Atcheson17.pdf},
   url = 	 {http://proceedings.mlr.press/v66/Atcheson17.html},
-  abstract = {Demonstrate application of Gaussian process regression (GPR) with convariance structure is able to make predictions of emotional arousal from audio with over twice the accuracy of straighforward pointwise application of GPR}
+  abstract = {Demonstrate application of Gaussian process regression (GPR) with covariance structure is able to make predictions of emotional arousal from audio with over twice the accuracy of straightforward pointwise application of GPR}
 }
 
 @InProceedings{Li17,


### PR DESCRIPTION
Rewrote `abtract = {}` manually for all papers to correct for potentially strange characters. Renamed proceedings to AFFYCOMP2017 for short. 